### PR TITLE
Remove version check from CXOne ScreenAgent download recipe

### DIFF
--- a/CXone/ScreenAgent.download.recipe.yaml
+++ b/CXone/ScreenAgent.download.recipe.yaml
@@ -1,16 +1,16 @@
 Description: Downloads the latest version of CXone ScreenAgent for macOS
-Identifier: com.github.williamtheaker.autopkg.download.ScreenAgent
+Identifier: com.github.olsonjp.autopkg.download.ScreenAgent
 MinimumVersion: "2.3" # First AutoPkg version with YAML recipe support
 
 Input:
   NAME: CXone ScreenAgent
 
 Process:
-  - Processor: URLTextSearcher
-    Comment: "Scrape DMG download URI."
-    Arguments:
-      url: https://downloads.incontact.com
-      re_pattern: https:\/\/staticfiles\.niceincontact\.com\/cxone-downloads\/ScreenAgent-64bit-[\d\.]*.dmg
+#  - Processor: URLTextSearcher
+#    Comment: "Scrape DMG download URI."
+#    Arguments:
+#      url: https://downloads.incontact.com
+#      re_pattern: https:\/\/staticfiles\.niceincontact\.com\/cxone-downloads\/ScreenAgent-64bit-[\d\.]*.dmg
 
   - Processor: URLDownloader
     Comment: "Download DMG."

--- a/CXone/ScreenAgent.munki.recipe.yaml
+++ b/CXone/ScreenAgent.munki.recipe.yaml
@@ -1,5 +1,6 @@
 Description: Downloads the latest version of CXone ScreenAgent for macOS and imports into Munki.
-Identifier: com.github.olsonjp.autopkg.munki.ScreenAgent
+Identifier: com.github.williamtheaker.autopkg.munki.ScreenAgent
+ParentRecipe: com.github.williamtheaker.autopkg.download.ScreenAgent
 MinimumVersion: "2.3" # First AutoPkg version with YAML recipe support
 
 Input:

--- a/CXone/ScreenAgent.munki.recipe.yaml
+++ b/CXone/ScreenAgent.munki.recipe.yaml
@@ -1,6 +1,6 @@
 Description: Downloads the latest version of CXone ScreenAgent for macOS and imports into Munki.
-Identifier: com.github.williamtheaker.autopkg.munki.ScreenAgent
-ParentRecipe: com.github.williamtheaker.autopkg.download.ScreenAgent
+Identifier: com.github.olsonjp.autopkg.munki.ScreenAgent
+ParentRecipe: com.github.olsonjp.autopkg.download.ScreenAgent
 MinimumVersion: "2.3" # First AutoPkg version with YAML recipe support
 
 Input:
@@ -22,7 +22,8 @@ Input:
       #!/bin/sh
       sh /Applications/ScreenAgent.app/Contents/Resources/install-screen-agent.sh REGION_TYPE=%REGION_TYPE% ACCESS_KEY_ID=%ACCESS_KEY_ID% ACCESS_KEY_SECRET=%ACCESS_KEY_SECRET% WEB_PROXY=%WEB_PROXY%
 
-#Process:
-#  - Processor: MunkiImporter
-#    Arguments:
-#      repo_subdirectory: "%MUNKI_REPO_SUBDIR%"
+Process:
+  - Processor: MunkiImporter
+    Arguments:
+      pkg_path: "%pathname%"
+      repo_subdirectory: "%MUNKI_REPO_SUBDIR%"


### PR DESCRIPTION
The ScreenAgent agent download URL now requires login so this skips the version check so we can pass the package locally.

Also reverting previous attempts to get this working.